### PR TITLE
melhora retrocompatibilidade com java 6+

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,9 @@ version := "0.9.14"
 
 scalaVersion := "2.11.11"
 
+javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint")
+scalacOptions in Compile += "-target:jvm-1.6"
+
 mainClass in (Compile, packageBin) := Some("br.edu.ifrn.potigol.Principal")
 
 assemblyOutputPath in assembly := file("jar/potigol.jar")

--- a/src/main/java/br/edu/ifrn/potigol/K.java
+++ b/src/main/java/br/edu/ifrn/potigol/K.java
@@ -120,19 +120,14 @@ public final class K {
 
     public static String operador(final String valor) {
         final String op;
-        switch (valor) {
-            case "mod":
-                op = "%";
-                break;
-            case "div":
-                op = "/";
-                break;
-            case "<>":
-                op = "!=";
-                break;
-            default:
-                op = valor;
-                break;
+        if ("mod".equals(valor)) {
+            op = "%";
+        } else if ("div".equals(valor)) {
+            op = "/";
+        } else if ("<>".equals(valor)) {
+            op = "!=";
+        } else {
+            op = valor;
         }
         return " " + op + " ";
     }

--- a/src/main/java/br/edu/ifrn/potigol/Listener.java
+++ b/src/main/java/br/edu/ifrn/potigol/Listener.java
@@ -200,8 +200,8 @@ public class Listener extends potigolBaseListener {
     @Override
     public void exitClasse(final ClasseContext ctx) {
         final String id = ctx.ID().getText();
-        List<ParseTree> cstr = new ArrayList<>();
-        List<ParseTree> elem = new ArrayList<>();
+        final List<ParseTree> cstr = new ArrayList<ParseTree>();
+        final List<ParseTree> elem = new ArrayList<ParseTree>();
         for (ParseTree child : ctx.children) {
             if (child.getClass().equals(DclContext.class)
                     || child.getClass().equals(Dcl_varContext.class)) {

--- a/src/main/java/br/edu/ifrn/potigol/ListenerData.java
+++ b/src/main/java/br/edu/ifrn/potigol/ListenerData.java
@@ -24,7 +24,7 @@ public class ListenerData {
     }
 
     public ListenerData() {
-        this.values = new ParseTreeProperty<>();
+        this.values = new ParseTreeProperty<String>();
         this.declaracoes = new Stack<List<String>>();
         this.warnings = new ArrayList<String>();
         this.saida = new StringBuilder();


### PR DESCRIPTION
Feito:

- [x] adicionada configuração via sbt para gerar *bytecode* compatível
- [x] ajustado código java existente para compilar em versões anteriores

Esta PR permite que os jars compilados possam ser executados por versão do java anterior a 7