### PR TITLE
corrige execução via jdk 9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "potigol"
 
 version := "0.9.14"
 
-scalaVersion := "2.11.11"
+scalaVersion := "2.11.12"
 
 javacOptions in Compile ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint")
 scalacOptions in Compile += "-target:jvm-1.6"
@@ -14,9 +14,9 @@ assemblyOutputPath in assembly := file("jar/potigol.jar")
 libraryDependencies ++= Seq(
   "org.antlr" % "antlr4" % "4.5.3",
   "org.antlr" % "antlr4-runtime" % "4.5.3",
-  "org.scala-lang" % "scala-library" % "2.11.11",
-  "org.scala-lang" % "scala-compiler" % "2.11.11",
-  "org.scala-lang" % "scala-reflect" % "2.11.11"
+  "org.scala-lang" % "scala-library" % "2.11.12",
+  "org.scala-lang" % "scala-compiler" % "2.11.12",
+  "org.scala-lang" % "scala-reflect" % "2.11.12"
 )
 
 enablePlugins(Antlr4Plugin)


### PR DESCRIPTION
Atualizada versões das libs pois o problema ` MissingRequirementError: object java.lang.Object in compiler mirror not found` foi corrigido na versão `2.11.12` da scala.

resolve #25 