### PR TITLE
Correção da chamada ao bash no exec.sh

### DIFF
--- a/jar/exec.sh
+++ b/jar/exec.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+!#/bin/bash
 
 gnome-terminal --title="$1 - Potigol" -x bash -c "java -jar potigol.jar -w -c $1; printf 'Pressione enter para sair ...'; read; exit 0; exec $SHELL";


### PR DESCRIPTION
O formato correto para iniciar o script é com o símbolo '!#' e não '#!' como está no código. Isso impede que o exec.sh seja executado corretamente e os código gerados com o epotigol.jar sejam executados em ambientes unix like por quem não tem conhecimentos de scrips *sh.